### PR TITLE
Reduce image size by building on top of debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM debian
 MAINTAINER Christian Lück <christian@lueck.tv>
 
-RUN apt-get update && apt-get install -y git php5-cli && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y git php5-cli php5-curl && \
+  rm -rf /var/lib/apt/lists/*
 ADD https://download.sculpin.io/sculpin.phar /usr/local/bin/sculpin
 RUN chmod 555 /usr/local/bin/sculpin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM php
+FROM debian
 MAINTAINER Christian Lück <christian@lueck.tv>
 
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git php5-cli && rm -rf /var/lib/apt/lists/*
 ADD https://download.sculpin.io/sculpin.phar /usr/local/bin/sculpin
 RUN chmod 555 /usr/local/bin/sculpin
 


### PR DESCRIPTION
Image size reduced from 420 MB to 188 MB.

Also, this fixes installation and update issues due to missing extensions (curl and gzip)
